### PR TITLE
Remove dependence on certifi

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -14,13 +14,6 @@
         ]
     },
     "default": {
-        "certifi": {
-            "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
-            ],
-            "version": "==2018.10.15"
-        },
         "e1839a8": {
             "editable": true,
             "extras": [
@@ -542,10 +535,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
             ],
-            "version": "==2.20.0"
+            "version": "==2.20.1"
         },
         "six": {
             "hashes": [

--- a/requests/certs.py
+++ b/requests/certs.py
@@ -12,7 +12,5 @@ If you are packaging Requests, e.g., for a Linux distribution or a managed
 environment, you can change the definition of where() to return a separately
 packaged CA bundle.
 """
-from certifi import where
-
-if __name__ == '__main__':
-    print(where())
+def where():
+  return None

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,7 @@ packages = ['requests']
 
 requires = [
     'idna>=2.5,<2.8',
-    'urllib3>=1.21.1,<1.25',
-    'certifi>=2017.4.17'
-
+    'urllib3>=1.21.1,<1.25'
 ]
 test_requirements = [
     'pytest-httpbin==0.0.7',


### PR DESCRIPTION
Trying to make a onprem compatible version of `requests`. @pfhayes I saw that you have your own fork, would it be more appropriate to keep using that one?