### PR TITLE
Remove chardet

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -21,13 +21,6 @@
             ],
             "version": "==2018.10.15"
         },
-        "chardet": {
-            "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
-            ],
-            "version": "==3.0.4"
-        },
         "e1839a8": {
             "editable": true,
             "extras": [

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -41,12 +41,11 @@ is at <http://python-requests.org>.
 """
 
 import urllib3
-import chardet
 import warnings
 from .exceptions import RequestsDependencyWarning
 
 
-def check_compatibility(urllib3_version, chardet_version):
+def check_compatibility(urllib3_version):
     urllib3_version = urllib3_version.split('.')
     assert urllib3_version != ['dev']  # Verify urllib3 isn't installed from git.
 
@@ -62,14 +61,6 @@ def check_compatibility(urllib3_version, chardet_version):
     assert minor >= 21
     assert minor <= 24
 
-    # Check chardet for compatibility.
-    major, minor, patch = chardet_version.split('.')[:3]
-    major, minor, patch = int(major), int(minor), int(patch)
-    # chardet >= 3.0.2, < 3.1.0
-    assert major == 3
-    assert minor < 1
-    assert patch >= 2
-
 
 def _check_cryptography(cryptography_version):
     # cryptography < 1.3.4
@@ -84,10 +75,10 @@ def _check_cryptography(cryptography_version):
 
 # Check imported dependencies for compatibility.
 try:
-    check_compatibility(urllib3.__version__, chardet.__version__)
+    check_compatibility(urllib3.__version__)
 except (AssertionError, ValueError):
-    warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
-                  "version!".format(urllib3.__version__, chardet.__version__),
+    warnings.warn("urllib3 ({}) doesn't match a supported "
+                  "version!".format(urllib3.__version__),
                   RequestsDependencyWarning)
 
 # Attempt to enable urllib3's SNI support, if possible

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -8,8 +8,6 @@ This module handles import compatibility issues between Python 2 and
 Python 3.
 """
 
-import chardet
-
 import sys
 
 # -------

--- a/requests/help.py
+++ b/requests/help.py
@@ -8,7 +8,6 @@ import ssl
 
 import idna
 import urllib3
-import chardet
 
 from . import __version__ as requests_version
 
@@ -71,7 +70,6 @@ def info():
 
     implementation_info = _implementation()
     urllib3_info = {'version': urllib3.__version__}
-    chardet_info = {'version': chardet.__version__}
 
     pyopenssl_info = {
         'version': None,
@@ -101,7 +99,6 @@ def info():
         'using_pyopenssl': pyopenssl is not None,
         'pyOpenSSL': pyopenssl_info,
         'urllib3': urllib3_info,
-        'chardet': chardet_info,
         'cryptography': cryptography_info,
         'idna': idna_info,
         'requests': {

--- a/requests/models.py
+++ b/requests/models.py
@@ -9,6 +9,7 @@ This module contains the primary objects that power Requests.
 
 import datetime
 import sys
+import warnings
 
 # Import encoding now, to avoid implicit import later.
 # Implicit import within threads may cause LookupError when standard library is in a ZIP,

--- a/requests/models.py
+++ b/requests/models.py
@@ -38,7 +38,7 @@ from .utils import (
 from .compat import (
     Callable, Mapping,
     cookielib, urlunparse, urlsplit, urlencode, str, bytes,
-    is_py2, chardet, builtin_str, basestring)
+    is_py2, builtin_str, basestring)
 from .compat import json as complexjson
 from .status_codes import codes
 
@@ -723,8 +723,8 @@ class Response(object):
 
     @property
     def apparent_encoding(self):
-        """The apparent encoding, provided by the chardet library."""
-        return chardet.detect(self.content)['encoding']
+        warnings.warn("Returning 'utf-8' because chardet was removed", RuntimeWarning)
+        return 'utf-8'
 
     def iter_content(self, chunk_size=1, decode_unicode=False):
         """Iterates over the response data.  When stream=True is set on the

--- a/requests/packages.py
+++ b/requests/packages.py
@@ -3,7 +3,7 @@ import sys
 # This code exists for backwards compatibility reasons.
 # I don't like it either. Just look the other way. :)
 
-for package in ('urllib3', 'idna', 'chardet'):
+for package in ('urllib3', 'idna'):
     locals()[package] = __import__(package)
     # This traversal is apparently necessary such that the identities are
     # preserved (requests.packages.urllib3.* is urllib3.*)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ if sys.argv[-1] == 'publish':
 packages = ['requests']
 
 requires = [
-    'chardet>=3.0.2,<3.1.0',
     'idna>=2.5,<2.8',
     'urllib3>=1.21.1,<1.25',
     'certifi>=2017.4.17'

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -7,7 +7,3 @@ def test_can_access_urllib3_attribute():
 
 def test_can_access_idna_attribute():
     requests.packages.idna
-
-
-def test_can_access_chardet_attribute():
-    requests.packages.chardet


### PR DESCRIPTION
This is a bit hacky, but `chardet` is only used for fallback encoding detection. This is replaced with defaulting to `utf-8` and emitting a `RuntimeWarning`